### PR TITLE
install postgresql-plperl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,11 +115,12 @@ mvn -f core/pom.xml org.andromda.maven.plugins:andromdapp-maven-plugin:schema -D
 mvn -f core/pom.xml org.andromda.maven.plugins:andromdapp-maven-plugin:schema -Dtasks=drop
 
 ###install postgres 13
-apt-get -y install postgresql
+apt-get -y install postgresql postgresql-plperl
 sudo -u postgres psql postgres -c "CREATE USER ctsms WITH PASSWORD 'ctsms';"
 sudo -u postgres psql postgres -c "CREATE DATABASE ctsms;"
 sudo -u postgres psql postgres -c "GRANT ALL PRIVILEGES ON DATABASE ctsms to ctsms;"
 sudo -u postgres psql postgres -c "ALTER DATABASE ctsms OWNER TO ctsms;"
+sudo -u postgres psql ctsms < /ctsms/build/ctsms/core/db/dbtool.sql
 sudo -u ctsms psql -U ctsms ctsms < /ctsms/build/ctsms/core/db/schema-create.sql
 sudo -u ctsms psql -U ctsms ctsms < /ctsms/build/ctsms/core/db/index-create.sql
 sudo -u ctsms psql -U ctsms ctsms < /ctsms/build/ctsms/core/db/schema-set-version.sql

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -72,6 +72,10 @@ fi
 mvn -f core/pom.xml org.andromda.maven.plugins:andromdapp-maven-plugin:schema -Dtasks=create
 mvn -f core/pom.xml org.andromda.maven.plugins:andromdapp-maven-plugin:schema -Dtasks=drop
 
+###install or remove packages
+apt-get -y install postgresql-plperl
+sudo -u postgres psql ctsms < /ctsms/build/ctsms/core/db/dbtool.sql
+
 ###apply database changes
 sudo -u ctsms psql -U ctsms ctsms < /ctsms/build/ctsms/core/db/schema-up-$TAG.sql
 


### PR DESCRIPTION
there are situations where SQL is not sufficient to do database schema changes.
this change therefor allows launch the phoenix dbtool from postgresql stored procedures.
this can eg. be used to initialize encrypted fields (with encrypted null values).

launching external programs from SQL works by enabling the "unsafe" plsql language (perl for postgresql) in postgresql. programs can be launched from perl snippets using the perl "system" or "qx" function. 